### PR TITLE
[DEV] HW BLE 및 HFP 프로토콜 구성

### DIFF
--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -1,11 +1,5 @@
 #include "ble_util.h"
 
-static const uint8_t adv_data[] = {
-    0x02, 0x01, 0x06,
-    0x03, 0x03, 0xAB, 0xCD,
-    0x0B, 0x09, 'P', 'E', 'E', 'P', 'E', 'R', '_', 'B', 'L', 'E'
-};
-
 static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
 {
     if (packet_type == HCI_EVENT_PACKET)
@@ -34,10 +28,6 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
 
 void	init_ble(void)
 {
-    l2cap_init();
-    sm_init();
-    gap_advertisements_set_params(0x0030, 0x0030, 0x00, 0x00, NULL, 0x07, 0x00);
-    gap_advertisements_set_data(sizeof(adv_data), (uint8_t*)adv_data);
-    gap_advertisements_enable(1);
-	btstack_run_loop_execute();
+	printf("## Initializing BLE\n");
+	printf("## Initialized BLE\n");
 }

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -10,7 +10,7 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
                 printf("Advertising report received\n");
                 break;
             case HCI_EVENT_COMMAND_COMPLETE:
-                printf("Command complete\n");
+                // printf("Command complete\n");
                 break;
             case HCI_EVENT_LE_META:
                 switch (hci_event_le_meta_get_subevent_code(packet))
@@ -29,5 +29,15 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
 void	init_ble(void)
 {
 	printf("## Initializing BLE\n");
+	l2cap_init();
+	sm_init();
+
+    gap_advertisements_enable(1);
+
+	static btstack_packet_callback_registration_t hci_event_callback_registration;
+    hci_event_callback_registration.callback = &ble_packet_handler;
+    hci_add_event_handler(&hci_event_callback_registration);
+
+    hci_power_control(HCI_POWER_ON);
 	printf("## Initialized BLE\n");
 }

--- a/main/ble_util.h
+++ b/main/ble_util.h
@@ -4,12 +4,9 @@
 # include "btstack.h"
 #include "esp_bt.h"
 #include "esp_bt_main.h"
+#include "gap.h"
 #include "hci.h"
-#include "hci_dump.h"
 #include "l2cap.h"
-#include "rfcomm.h"
-#include "sdp_server.h"
-#include "hfp_hf.h"
 
 void	init_ble(void);
 

--- a/main/hfp_util.c
+++ b/main/hfp_util.c
@@ -72,7 +72,6 @@ void	init_hfp(void)
     hci_event_callback_registration.callback = &hfp_packet_handler;
     hci_add_event_handler(&hci_event_callback_registration);
     hci_register_sco_packet_handler(&hfp_packet_handler);
-    hci_register_sco_packet_handler(&hfp_packet_handler);
 
     hfp_hf_register_packet_handler(hfp_packet_handler);
 

--- a/main/hfp_util.c
+++ b/main/hfp_util.c
@@ -1,17 +1,81 @@
 #include "hfp_util.h"
 
+uint8_t			hfp_service_buffer[150];
+const char		*hfp_device_name = "PEEPER";
+const uint8_t	rfcomm_channel_nr = 1;
+static uint8_t	codecs[] = {HFP_CODEC_CVSD, HFP_CODEC_MSBC};
+static uint16_t	indicators[1] = {0x01};
+static btstack_packet_callback_registration_t	hci_event_callback_registration;
+static hci_con_handle_t sco_handle = HCI_CON_HANDLE_INVALID;
+
 static void	hfp_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
 {
-    // HFP 관련 패킷 처리 코드 추가
+    if (packet_type == HCI_SCO_DATA_PACKET)
+	{
+		// PCM Data Packet
+	}
+	else
+	{
+        switch (hci_event_packet_get_type(packet))
+		{
+            case HCI_EVENT_SCO_CAN_SEND_NOW:
+				printf("Sendable from Now");
+				break;
+            case HCI_EVENT_COMMAND_COMPLETE:
+                printf("Command complete\n");
+                break;
+			case HCI_EVENT_HFP_META:
+				switch(hci_event_hfp_meta_get_subevent_code(packet))
+				{
+					case HFP_SUBEVENT_RING:
+						printf("** Ring **\n");
+						break;
+					case HFP_SUBEVENT_CALLING_LINE_IDENTIFICATION_NOTIFICATION:
+						printf("Caller ID, number %s\n", hfp_subevent_calling_line_identification_notification_get_number(packet));
+						break;
+				}
+            default:
+                break;
+        }
+    }
 }
 
 void	init_hfp(void)
 {
+	printf("## Initializing HFP\n");
+    gap_discoverable_control(1);
+    gap_set_class_of_device(0x200408);
+    gap_set_local_name(hfp_device_name);
+
     l2cap_init();
+
+    uint16_t hf_supported_features =
+        (1 << HFP_HFSF_ESCO_S4) |
+        (1 << HFP_HFSF_CLI_PRESENTATION_CAPABILITY) |
+        (1 << HFP_HFSF_HF_INDICATORS) |
+        (1 << HFP_HFSF_CODEC_NEGOTIATION) |
+        (1 << HFP_HFSF_ENHANCED_CALL_STATUS) |
+        (1 << HFP_HFSF_REMOTE_VOLUME_CONTROL);
+    int wide_band_speech = 1;
+
     rfcomm_init();
+    hfp_hf_init(rfcomm_channel_nr);
+    hfp_hf_init_supported_features(hf_supported_features);
+    hfp_hf_init_hf_indicators(sizeof(indicators) / sizeof(uint16_t), indicators);
+    hfp_hf_init_codecs(sizeof(codecs), codecs);
+
     sdp_init();
-    hci_register_sco_packet_handler(hfp_packet_handler);
-    hfp_hf_init(0);
+    memset(hfp_service_buffer, 0, sizeof(hfp_service_buffer));
+    hfp_hf_create_sdp_record(hfp_service_buffer, 0x10001, rfcomm_channel_nr, hfp_device_name, hf_supported_features, wide_band_speech);
+    sdp_register_service(hfp_service_buffer);
+
+    hci_event_callback_registration.callback = &hfp_packet_handler;
+    hci_add_event_handler(&hci_event_callback_registration);
+    hci_register_sco_packet_handler(&hfp_packet_handler);
+    hci_register_sco_packet_handler(&hfp_packet_handler);
+
     hfp_hf_register_packet_handler(hfp_packet_handler);
-    sdp_register_service(NULL);
+
+    hci_power_control(HCI_POWER_ON);
+	printf("## Initialized HFP\n");
 }

--- a/main/hfp_util.c
+++ b/main/hfp_util.c
@@ -22,7 +22,7 @@ static void	hfp_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
 				printf("Sendable from Now");
 				break;
             case HCI_EVENT_COMMAND_COMPLETE:
-                printf("Command complete\n");
+                // printf("Command complete\n");
                 break;
 			case HCI_EVENT_HFP_META:
 				switch(hci_event_hfp_meta_get_subevent_code(packet))

--- a/main/main.c
+++ b/main/main.c
@@ -1,6 +1,7 @@
 #include "btstack_audio.h"
 #include "btstack_port_esp32.h"
 #include "btstack_run_loop.h"
+#include "nvs_flash.h"
 
 #include "ble_util.h"
 #include "hfp_util.h"
@@ -10,6 +11,15 @@ extern int btstack_main(int argc, const char *argv[]);
 
 int app_main(void)
 {
+	nvs_flash_erase();
+	nvs_flash_init();
+
+	esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
+    esp_bt_controller_init(&bt_cfg);
+    esp_bt_controller_enable(ESP_BT_MODE_BTDM);
+    esp_bluedroid_init();
+    esp_bluedroid_enable();
+
     btstack_init();
 
     btstack_audio_source_set_instance(btstack_audio_esp32_source_get_instance());

--- a/main/main.c
+++ b/main/main.c
@@ -14,12 +14,6 @@ int app_main(void)
 	nvs_flash_erase();
 	nvs_flash_init();
 
-	esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-    esp_bt_controller_init(&bt_cfg);
-    esp_bt_controller_enable(ESP_BT_MODE_BTDM);
-    esp_bluedroid_init();
-    esp_bluedroid_enable();
-
     btstack_init();
 
     btstack_audio_source_set_instance(btstack_audio_esp32_source_get_instance());


### PR DESCRIPTION
## Summary
BLE 및 HFP 프로토콜을 활성화하고, 패킷 처리부를 구현하였습니다.

## Description
- `ble_util`과 `hfp_util`을 구성하여, 각각에서 BLE 및 HFP 프로토콜을 초기화하도록 하였습니다.
- `init_ble` 및 `init_hfp` 함수는 각 프로토콜을 초기화하고, Scan을 활성화하는 함수입니다.
- 각각 `ble_packet_handler` 및 `hfp_packet_handler`를 연동하여 수신된 Packet을 처리할 수 있도록 하였습니다.
- `PEEPER`라는 장치 이름으로 Scan이 가능하며, HFP 프로토콜로 연결 시, 앱에서 BLE 프로토콜에 접근 가능하도록 하였습니다.
