### PR TITLE
[DEV] HW PCM 데이터 처리 구성

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
-        SRCS "main.c" "ble_util.c" "hfp_util.c" "pcm_util.c"
+        SRCS "processing_util.c" "main.c" "ble_util.c" "hfp_util.c" "pcm_util.c"
         INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}")

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -5,16 +5,10 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
     if (packet_type == HCI_EVENT_PACKET)
 	{
         switch (hci_event_packet_get_type(packet))
-		{
-            case GAP_EVENT_ADVERTISING_REPORT:
-                printf("Advertising report received\n");
-                break;
-            case HCI_EVENT_COMMAND_COMPLETE:
-                // printf("Command complete\n");
-                break;
+        {
             case HCI_EVENT_LE_META:
                 switch (hci_event_le_meta_get_subevent_code(packet))
-				{
+                {
                     case HCI_SUBEVENT_LE_CONNECTION_COMPLETE:
                         printf("LE Connection complete\n");
                         break;

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -1,5 +1,11 @@
 #include "ble_util.h"
 
+static uint8_t service_uuid[16];
+static uint8_t characteristic_uuid[16];
+
+static uint16_t connection_handle = HCI_CON_HANDLE_INVALID;
+static uint16_t att_handle = 0;
+
 static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
 {
     if (packet_type == HCI_EVENT_PACKET)
@@ -10,6 +16,7 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
                 switch (hci_event_le_meta_get_subevent_code(packet))
                 {
                     case HCI_SUBEVENT_LE_CONNECTION_COMPLETE:
+                        connection_handle = hci_subevent_le_connection_complete_get_connection_handle(packet);
                         printf("LE Connection complete\n");
                         break;
                 }
@@ -20,11 +27,26 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
     }
 }
 
+void ble_send_data(uint8_t *data, uint16_t length)
+{
+    if (connection_handle != HCI_CON_HANDLE_INVALID && att_handle != 0)
+    {
+        att_server_notify(connection_handle, att_handle, data, length);
+    }
+}
+
 void	init_ble(void)
 {
 	printf("## Initializing BLE\n");
 	l2cap_init();
 	sm_init();
+
+	att_db_util_init();
+    att_db_util_add_service_uuid128(service_uuid);
+    att_handle = att_db_util_add_characteristic_uuid128(characteristic_uuid, ATT_PROPERTY_NOTIFY, ATT_SECURITY_NONE, ATT_SECURITY_NONE, NULL, NULL);
+
+    att_server_init(att_db_util_get_address(), NULL, NULL);
+    att_server_register_packet_handler(ble_packet_handler);
 
 	uint16_t adv_interval_min = 0x0020;
     uint16_t adv_interval_max = 0x0030;

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -21,6 +21,10 @@ static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *p
                         break;
                 }
                 break;
+			case HCI_EVENT_DISCONNECTION_COMPLETE:
+                connection_handle = HCI_CON_HANDLE_INVALID;
+				printf("LE Disconnection complete\n");
+                break;
             default:
                 break;
         }

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -32,6 +32,20 @@ void	init_ble(void)
 	l2cap_init();
 	sm_init();
 
+	uint16_t adv_interval_min = 0x0020;
+    uint16_t adv_interval_max = 0x0030;
+    uint8_t adv_type = 0x00;
+    uint8_t own_address_type = 0x00;
+    uint8_t direct_address_type = 0x00;
+    uint8_t direct_address[6] = {0};
+    uint8_t adv_channel_map = 0x07;
+    uint8_t adv_filter_policy = 0x00;
+    gap_advertisements_set_params(adv_interval_min, adv_interval_max, adv_type,
+                                  direct_address_type, direct_address,
+                                  adv_channel_map, adv_filter_policy);
+
+	uint8_t adv_data[] = { 0x02, 0x01, 0x06 };
+    gap_advertisements_set_data(sizeof(adv_data), adv_data);
     gap_advertisements_enable(1);
 
 	static btstack_packet_callback_registration_t hci_event_callback_registration;

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -6,6 +6,19 @@ static uint8_t characteristic_uuid[16];
 static uint16_t connection_handle = HCI_CON_HANDLE_INVALID;
 static uint16_t att_handle = 0;
 
+static btstack_timer_source_t data_timer;
+
+static void send_data_timer_handler(btstack_timer_source_t *ts)
+{
+    if (connection_handle != HCI_CON_HANDLE_INVALID && att_handle != 0)
+    {
+        uint8_t data[] = { 'H', 'e', 'l', 'l', 'o' };
+        att_server_notify(connection_handle, att_handle, data, sizeof(data));
+    }
+    btstack_run_loop_set_timer(ts, 1000);
+    btstack_run_loop_add_timer(ts);
+}
+
 static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
 {
     if (packet_type == HCI_EVENT_PACKET)
@@ -73,5 +86,9 @@ void	init_ble(void)
     hci_add_event_handler(&hci_event_callback_registration);
 
     hci_power_control(HCI_POWER_ON);
+
+	btstack_run_loop_set_timer_handler(&data_timer, send_data_timer_handler);
+    btstack_run_loop_set_timer(&data_timer, 1000);
+    btstack_run_loop_add_timer(&data_timer);
 	printf("## Initialized BLE\n");
 }

--- a/main/ble_util.c
+++ b/main/ble_util.c
@@ -6,19 +6,6 @@ static uint8_t characteristic_uuid[16];
 static uint16_t connection_handle = HCI_CON_HANDLE_INVALID;
 static uint16_t att_handle = 0;
 
-static btstack_timer_source_t data_timer;
-
-static void send_data_timer_handler(btstack_timer_source_t *ts)
-{
-    if (connection_handle != HCI_CON_HANDLE_INVALID && att_handle != 0)
-    {
-        uint8_t data[] = { 'H', 'e', 'l', 'l', 'o' };
-        att_server_notify(connection_handle, att_handle, data, sizeof(data));
-    }
-    btstack_run_loop_set_timer(ts, 1000);
-    btstack_run_loop_add_timer(ts);
-}
-
 static void	ble_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
 {
     if (packet_type == HCI_EVENT_PACKET)
@@ -86,9 +73,5 @@ void	init_ble(void)
     hci_add_event_handler(&hci_event_callback_registration);
 
     hci_power_control(HCI_POWER_ON);
-
-	btstack_run_loop_set_timer_handler(&data_timer, send_data_timer_handler);
-    btstack_run_loop_set_timer(&data_timer, 1000);
-    btstack_run_loop_add_timer(&data_timer);
 	printf("## Initialized BLE\n");
 }

--- a/main/ble_util.h
+++ b/main/ble_util.h
@@ -8,6 +8,7 @@
 #include "hci.h"
 #include "l2cap.h"
 
+void	ble_send_data(uint8_t *data, uint16_t length);
 void	init_ble(void);
 
 #endif

--- a/main/hfp_util.c
+++ b/main/hfp_util.c
@@ -1,48 +1,148 @@
 #include "hfp_util.h"
 
 uint8_t			hfp_service_buffer[150];
+const char		*hfp_device_addr = "E4:65:B8:76:CE:2A";
 const char		*hfp_device_name = "PEEPER";
 const uint8_t	rfcomm_channel_nr = 1;
 static uint8_t	codecs[] = {HFP_CODEC_CVSD, HFP_CODEC_MSBC};
+static uint8_t	negotiated_codec = HFP_CODEC_CVSD;
 static uint16_t	indicators[1] = {0x01};
 static btstack_packet_callback_registration_t	hci_event_callback_registration;
-static hci_con_handle_t sco_handle = HCI_CON_HANDLE_INVALID;
+static hci_con_handle_t	acl_handle = HCI_CON_HANDLE_INVALID;
+static hci_con_handle_t	sco_handle = HCI_CON_HANDLE_INVALID;
+static bd_addr_t device_addr;
 
-static void	hfp_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size)
+static void	hfp_packet_handler(uint8_t packet_type, uint16_t channel, uint8_t *event, uint16_t event_size)
 {
-    if (packet_type == HCI_SCO_DATA_PACKET)
-	{
-		// PCM Data Packet
-	}
-	else
-	{
-        switch (hci_event_packet_get_type(packet))
-		{
-            case HCI_EVENT_SCO_CAN_SEND_NOW:
-				printf("Sendable from Now");
-				break;
-            case HCI_EVENT_COMMAND_COMPLETE:
-                // printf("Command complete\n");
+    UNUSED(channel);
+    uint8_t status;
+
+    switch (packet_type)
+    {
+
+    case HCI_SCO_DATA_PACKET:
+        if (READ_SCO_CONNECTION_HANDLE(event) != sco_handle)
+            break;
+        processing_receive(event, event_size);
+        break;
+
+    case HCI_EVENT_PACKET:
+        switch (hci_event_packet_get_type(event))
+        {
+        case HCI_EVENT_SCO_CAN_SEND_NOW:
+            // processing_send(sco_handle);
+            break;
+
+        case HCI_EVENT_HFP_META:
+            switch (hci_event_hfp_meta_get_subevent_code(event))
+            {
+            case HFP_SUBEVENT_SERVICE_LEVEL_CONNECTION_ESTABLISHED:
+                acl_handle = hfp_subevent_service_level_connection_established_get_acl_handle(event);
+                hfp_subevent_service_level_connection_established_get_bd_addr(event, device_addr);
+                printf("Service level connection established %s.\n\n", bd_addr_to_str(device_addr));
                 break;
-			case HCI_EVENT_HFP_META:
-				switch(hci_event_hfp_meta_get_subevent_code(packet))
-				{
-					case HFP_SUBEVENT_RING:
-						printf("** Ring **\n");
-						break;
-					case HFP_SUBEVENT_CALLING_LINE_IDENTIFICATION_NOTIFICATION:
-						printf("Caller ID, number %s\n", hfp_subevent_calling_line_identification_notification_get_number(packet));
-						break;
-				}
+            case HFP_SUBEVENT_SERVICE_LEVEL_CONNECTION_RELEASED:
+                acl_handle = HCI_CON_HANDLE_INVALID;
+                printf("Service level connection released.\n\n");
+                break;
+            case HFP_SUBEVENT_AUDIO_CONNECTION_ESTABLISHED:
+                status = hfp_subevent_audio_connection_established_get_status(event);
+                if (status != ERROR_CODE_SUCCESS)
+                {
+                    printf("Audio connection establishment failed with status 0x%02x\n", status);
+                }
+                else
+                {
+                    sco_handle = hfp_subevent_audio_connection_established_get_sco_handle(event);
+                    printf("Audio connection established with SCO handle 0x%04x.\n", sco_handle);
+                    negotiated_codec = hfp_subevent_audio_connection_established_get_negotiated_codec(event);
+                    switch (negotiated_codec)
+                    {
+                    case 0x01:
+                        printf("Using CVSD codec.\n");
+                        break;
+                    case 0x02:
+                        printf("Using mSBC codec.\n");
+                        break;
+                    default:
+                        printf("Using unknown codec 0x%02x.\n", negotiated_codec);
+                        break;
+                    }
+                    processing_set_codec(negotiated_codec);
+                    hci_request_sco_can_send_now_event();
+                }
+                break;
+            case HFP_SUBEVENT_AUDIO_CONNECTION_RELEASED:
+                sco_handle = HCI_CON_HANDLE_INVALID;
+                printf("Audio connection released\n");
+                processing_close();
+                break;
+            case HFP_SUBEVENT_AG_INDICATOR_STATUS_CHANGED:
+                printf("AG_INDICATOR_STATUS_CHANGED, AG indicator (index: %d) to: %d of range [%d, %d], name '%s'\n",
+                       hfp_subevent_ag_indicator_status_changed_get_indicator_index(event),
+                       hfp_subevent_ag_indicator_status_changed_get_indicator_status(event),
+                       hfp_subevent_ag_indicator_status_changed_get_indicator_min_range(event),
+                       hfp_subevent_ag_indicator_status_changed_get_indicator_max_range(event),
+                       (const char *)hfp_subevent_ag_indicator_status_changed_get_indicator_name(event));
+                break;
+            case HFP_SUBEVENT_NETWORK_OPERATOR_CHANGED:
+                printf("NETWORK_OPERATOR_CHANGED, operator mode: %d, format: %d, name: %s\n",
+                       hfp_subevent_network_operator_changed_get_network_operator_mode(event),
+                       hfp_subevent_network_operator_changed_get_network_operator_format(event),
+                       (char *)hfp_subevent_network_operator_changed_get_network_operator_name(event));
+                break;
+            case HFP_SUBEVENT_EXTENDED_AUDIO_GATEWAY_ERROR:
+                printf("EXTENDED_AUDIO_GATEWAY_ERROR_REPORT, status : 0x%02x\n",
+                       hfp_subevent_extended_audio_gateway_error_get_error(event));
+                break;
+            case HFP_SUBEVENT_RING:
+                printf("** Ring **\n");
+                break;
+            case HFP_SUBEVENT_NUMBER_FOR_VOICE_TAG:
+                printf("Phone number for voice tag: %s\n",
+                       (const char *)hfp_subevent_number_for_voice_tag_get_number(event));
+                break;
+            case HFP_SUBEVENT_SPEAKER_VOLUME:
+                printf("Speaker volume: gain %u\n",
+                       hfp_subevent_speaker_volume_get_gain(event));
+                break;
+            case HFP_SUBEVENT_MICROPHONE_VOLUME:
+                printf("Microphone volume: gain %u\n",
+                       hfp_subevent_microphone_volume_get_gain(event));
+                break;
+            case HFP_SUBEVENT_CALLING_LINE_IDENTIFICATION_NOTIFICATION:
+                printf("Caller ID, number %s\n", hfp_subevent_calling_line_identification_notification_get_number(event));
+                break;
+            case HFP_SUBEVENT_ENHANCED_CALL_STATUS:
+                printf("Enhanced call status:\n");
+                printf("  - call index: %d \n", hfp_subevent_enhanced_call_status_get_clcc_idx(event));
+                printf("  - direction : %s \n", hfp_enhanced_call_dir2str(hfp_subevent_enhanced_call_status_get_clcc_dir(event)));
+                printf("  - status    : %s \n", hfp_enhanced_call_status2str(hfp_subevent_enhanced_call_status_get_clcc_status(event)));
+                printf("  - mode      : %s \n", hfp_enhanced_call_mode2str(hfp_subevent_enhanced_call_status_get_clcc_mode(event)));
+                printf("  - multipart : %s \n", hfp_enhanced_call_mpty2str(hfp_subevent_enhanced_call_status_get_clcc_mpty(event)));
+                printf("  - type      : %d \n", hfp_subevent_enhanced_call_status_get_bnip_type(event));
+                printf("  - number    : %s \n", hfp_subevent_enhanced_call_status_get_bnip_number(event));
+                break;
             default:
                 break;
+            }
+            break;
+
+        default:
+            break;
         }
+        break;
+
+    default:
+        break;
     }
 }
 
 void	init_hfp(void)
 {
 	printf("## Initializing HFP\n");
+	processing_init();
+
     gap_discoverable_control(1);
     gap_set_class_of_device(0x200408);
     gap_set_local_name(hfp_device_name);
@@ -68,6 +168,7 @@ void	init_hfp(void)
     memset(hfp_service_buffer, 0, sizeof(hfp_service_buffer));
     hfp_hf_create_sdp_record(hfp_service_buffer, 0x10001, rfcomm_channel_nr, hfp_device_name, hf_supported_features, wide_band_speech);
     sdp_register_service(hfp_service_buffer);
+	printf("SDP service record size: %lu\n", de_get_len(hfp_service_buffer));
 
     hci_event_callback_registration.callback = &hfp_packet_handler;
     hci_add_event_handler(&hci_event_callback_registration);
@@ -76,5 +177,6 @@ void	init_hfp(void)
     hfp_hf_register_packet_handler(hfp_packet_handler);
 
     hci_power_control(HCI_POWER_ON);
+	sscanf_bd_addr(hfp_device_addr, device_addr);
 	printf("## Initialized HFP\n");
 }

--- a/main/hfp_util.h
+++ b/main/hfp_util.h
@@ -2,14 +2,16 @@
 # define HFP_UTIL_H
 
 # include "btstack.h"
-#include "esp_bt.h"
-#include "esp_bt_main.h"
-#include "hci.h"
-#include "hci_dump.h"
-#include "l2cap.h"
-#include "rfcomm.h"
-#include "sdp_server.h"
-#include "hfp_hf.h"
+# include "esp_bt.h"
+# include "esp_bt_main.h"
+# include "hci.h"
+# include "hci_dump.h"
+# include "l2cap.h"
+# include "rfcomm.h"
+# include "sdp_server.h"
+# include "hfp_hf.h"
+
+# include "processing_util.h"
 
 void	init_hfp(void);
 

--- a/main/main.c
+++ b/main/main.c
@@ -1,7 +1,6 @@
 #include "btstack_audio.h"
 #include "btstack_port_esp32.h"
 #include "btstack_run_loop.h"
-#include "nvs_flash.h"
 
 #include "ble_util.h"
 #include "hfp_util.h"
@@ -9,9 +8,6 @@
 
 int app_main(void)
 {
-	nvs_flash_erase();
-	nvs_flash_init();
-
     btstack_init();
 
     btstack_audio_source_set_instance(btstack_audio_esp32_source_get_instance());

--- a/main/main.c
+++ b/main/main.c
@@ -7,8 +7,6 @@
 #include "hfp_util.h"
 #include "pcm_util.h"
 
-extern int btstack_main(int argc, const char *argv[]);
-
 int app_main(void)
 {
 	nvs_flash_erase();

--- a/main/pcm_util.c
+++ b/main/pcm_util.c
@@ -10,7 +10,17 @@ void	log_pcm_data(const int16_t *pcm_data, int num_samples)
     printf("\n");
 }
 
-void	send_pcm_Data(const int16_t *pcm_data, int num_samples)
+void	send_pcm_data(const int16_t *pcm_data, int num_samples)
 {
+    uint8_t	output_buffer[num_samples * 2];
 
+    for(int i = 0; i < num_samples; i++)
+	{
+        output_buffer[i * 2] = (uint8_t)(pcm_data[i] & 0xFF);
+        output_buffer[i * 2 + 1] = (uint8_t)((pcm_data[i] >> 8) & 0xFF);
+    }
+
+	for(int i = 0; i < num_samples * 2; i += 10){
+		ble_send_data(output_buffer + i, 10);
+	}
 }

--- a/main/pcm_util.c
+++ b/main/pcm_util.c
@@ -4,12 +4,10 @@ int16_t	pcm_data[PCM_BUFFER_SIZE];
 int		pcm_data_size = 0;
 
 void log_pcm_data(const int16_t *pcm_data, int num_samples) {
-	printf("%d (Size %d)", pcm_data[0], pcm_data_size);
-    // for (int i = 0; i < num_samples; i++) {
-    //     printf("%d ", pcm_data[i]);
-    //     if (i % 20 == 19) {
-    //         printf("\n");
-    //     }
-    // }
+	printf("(Size %d) : ", num_samples);
+	int log_size = num_samples < 10 ? num_samples : 10;
+    for(int i = 0; i < log_size; i++) {
+        printf("%d ", pcm_data[i]);
+    }
     printf("\n");
 }

--- a/main/pcm_util.c
+++ b/main/pcm_util.c
@@ -1,13 +1,16 @@
 #include "pcm_util.h"
 
-int16_t	pcm_data[PCM_BUFFER_SIZE];
-int		pcm_data_size = 0;
-
-void log_pcm_data(const int16_t *pcm_data, int num_samples) {
+void	log_pcm_data(const int16_t *pcm_data, int num_samples)
+{
 	printf("(Size %d) : ", num_samples);
 	int log_size = num_samples < 10 ? num_samples : 10;
     for(int i = 0; i < log_size; i++) {
         printf("%d ", pcm_data[i]);
     }
     printf("\n");
+}
+
+void	send_pcm_Data(const int16_t *pcm_data, int num_samples)
+{
+
 }

--- a/main/pcm_util.h
+++ b/main/pcm_util.h
@@ -7,11 +7,6 @@
 
 # include "ble_util.h"
 
-# define PCM_BUFFER_SIZE 240
-
-extern int16_t	pcm_data[PCM_BUFFER_SIZE];
-extern int		pcm_data_size;
-
 void	log_pcm_data(const int16_t *pcm_data, int num_samples);
 void	send_pcm_data(const int16_t *pcm_data, int num_samples);
 

--- a/main/pcm_util.h
+++ b/main/pcm_util.h
@@ -1,10 +1,11 @@
 #ifndef BLE_PCM_UTIL_H
 # define BLE_PCM_UTIL_H
 
-// # include <stddef.h>
 # include <stdint.h>
 # include <stdio.h>
 # include <string.h>
+
+# include "ble_util.h"
 
 # define PCM_BUFFER_SIZE 240
 
@@ -12,5 +13,6 @@ extern int16_t	pcm_data[PCM_BUFFER_SIZE];
 extern int		pcm_data_size;
 
 void	log_pcm_data(const int16_t *pcm_data, int num_samples);
+void	send_pcm_data(const int16_t *pcm_data, int num_samples);
 
 #endif

--- a/main/processing_util.c
+++ b/main/processing_util.c
@@ -1,0 +1,244 @@
+#include "processing_util.h"
+
+static int		audio_input_paused = 0;
+static uint8_t	audio_input_ring_buffer_storage[2 * 8000];
+static btstack_ring_buffer_t audio_input_ring_buffer;
+
+static int		audio_output_paused = 0;
+static uint8_t	audio_output_ring_buffer_storage[2 * MSBC_PA_PREBUFFER_BYTES];
+static btstack_ring_buffer_t audio_output_ring_buffer;
+
+static int	dump_data = 1;
+static int	count_sent = 0;
+static int	count_received = 0;
+static int	negotiated_codec = -1;
+
+static btstack_sbc_decoder_state_t decoder_state;
+
+int	num_audio_frames;
+int	num_samples_to_write;
+unsigned int phase;
+
+static void playback_callback(int16_t *buffer, uint16_t num_samples)
+{
+    uint32_t prebuffer_bytes;
+	prebuffer_bytes = MSBC_PA_PREBUFFER_BYTES;
+
+    if (audio_output_paused)
+    {
+        if (btstack_ring_buffer_bytes_available(&audio_output_ring_buffer) < prebuffer_bytes)
+        {
+            memset(buffer, 0, num_samples * BYTES_PER_FRAME);
+            return;
+        }
+        audio_output_paused = 0;
+    }
+
+    uint32_t bytes_read = 0;
+    btstack_ring_buffer_read(&audio_output_ring_buffer, (uint8_t *)buffer, num_samples * BYTES_PER_FRAME, &bytes_read);
+    num_samples -= bytes_read / BYTES_PER_FRAME;
+    buffer += bytes_read / BYTES_PER_FRAME;
+
+    if (num_samples)
+    {
+        memset(buffer, 0, num_samples * BYTES_PER_FRAME);
+        audio_output_paused = 1;
+    }
+}
+
+static void recording_callback(const int16_t *buffer, uint16_t num_samples)
+{
+    btstack_ring_buffer_write(&audio_input_ring_buffer, (uint8_t *)buffer, num_samples * 2);
+}
+
+static int audio_initialize(int sample_rate)
+{
+    memset(audio_output_ring_buffer_storage, 0, sizeof(audio_output_ring_buffer_storage));
+    btstack_ring_buffer_init(&audio_output_ring_buffer, audio_output_ring_buffer_storage, sizeof(audio_output_ring_buffer_storage));
+
+    const btstack_audio_sink_t *audio_sink = btstack_audio_sink_get_instance();
+    if (audio_sink)
+    {
+        audio_sink->init(1, sample_rate, &playback_callback);
+        audio_sink->start_stream();
+        audio_output_paused = 1;
+    }
+
+    memset(audio_input_ring_buffer_storage, 0, sizeof(audio_input_ring_buffer_storage));
+    btstack_ring_buffer_init(&audio_input_ring_buffer, audio_input_ring_buffer_storage, sizeof(audio_input_ring_buffer_storage));
+
+    const btstack_audio_source_t *audio_source = btstack_audio_source_get_instance();
+    if (audio_source)
+    {
+        audio_source->init(1, sample_rate, &recording_callback);
+        audio_source->start_stream();
+        audio_input_paused = 1;
+    }
+    return 1;
+}
+
+static void audio_terminate(void)
+{
+    const btstack_audio_sink_t *audio_sink = btstack_audio_sink_get_instance();
+    if (audio_sink)
+    {
+        audio_sink->close();
+    }
+
+    const btstack_audio_source_t *audio_source = btstack_audio_source_get_instance();
+    if (audio_source)
+    {
+        audio_source->close();
+    }
+}
+
+static void handle_pcm_data(int16_t *data, int num_samples, int num_channels, int sample_rate, void *context)
+{
+    UNUSED(context);
+    UNUSED(sample_rate);
+    UNUSED(data);
+    UNUSED(num_samples);
+    UNUSED(num_channels);
+
+    btstack_ring_buffer_write(&audio_output_ring_buffer, (uint8_t *)data, num_samples * num_channels * 2);
+}
+
+static void processing_init_mSBC(void)
+{
+    printf("Processing: Init mSBC\n");
+
+    btstack_sbc_decoder_init(&decoder_state, SBC_MODE_mSBC, &handle_pcm_data, NULL);
+    hfp_msbc_init();
+
+    audio_initialize(MSBC_SAMPLE_RATE);
+}
+
+static void processing_receive_mSBC(uint8_t *packet, uint16_t size)
+{
+    btstack_sbc_decoder_process_data(&decoder_state, (packet[1] >> 4) & 3, packet + 3, size - 3);
+}
+
+void processing_close(void)
+{
+    printf("SCO demo close\n");
+
+    printf("SCO demo statistics: ");
+    printf("Used mSBC with PLC, number of processed frames: \n - %d good frames, \n - %d zero frames, \n - %d bad frames.\n", decoder_state.good_frames_nr, decoder_state.zero_frames_nr, decoder_state.bad_frames_nr);
+    audio_terminate();
+}
+
+void processing_set_codec(uint8_t codec)
+{
+    if (negotiated_codec == codec)
+        return;
+    negotiated_codec = codec;
+    processing_init_mSBC();
+}
+
+void processing_init(void)
+{
+    printf("Processing: Sending and receiving audio via btstack_audio.\n");
+    hci_set_sco_voice_setting(0x60);
+}
+
+void sco_report(void)
+{
+    printf("SCO: sent %u, received %u\n", count_sent, count_received);
+}
+
+void processing_send(hci_con_handle_t sco_handle)
+{
+    if (sco_handle == HCI_CON_HANDLE_INVALID)
+        return;
+
+    int sco_packet_length = hci_get_sco_packet_length();
+    int sco_payload_length = sco_packet_length - 3;
+
+    hci_reserve_packet_buffer();
+    uint8_t *sco_packet = hci_get_outgoing_packet_buffer();
+
+    if (btstack_audio_source_get_instance())
+    {
+		if (audio_input_paused)
+		{
+			if (btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= MSBC_PA_PREBUFFER_BYTES)
+			{
+				audio_input_paused = 0;
+			}
+		}
+
+		if (!audio_input_paused)
+		{
+			int num_samples = hfp_msbc_num_audio_samples_per_frame();
+			if (num_samples > MAX_NUM_MSBC_SAMPLES)
+				return;
+			if (hfp_msbc_can_encode_audio_frame_now() && btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= (unsigned int)(num_samples * BYTES_PER_FRAME))
+			{
+				int16_t sample_buffer[MAX_NUM_MSBC_SAMPLES];
+				uint32_t bytes_read;
+				btstack_ring_buffer_read(&audio_input_ring_buffer, (uint8_t *)sample_buffer, num_samples * BYTES_PER_FRAME, &bytes_read);
+				hfp_msbc_encode_audio_frame(sample_buffer);
+				num_audio_frames++;
+			}
+			if (hfp_msbc_num_bytes_in_stream() < sco_payload_length)
+			{
+				log_error("mSBC stream should not be empty.");
+			}
+		}
+
+		if (audio_input_paused || hfp_msbc_num_bytes_in_stream() < sco_payload_length)
+		{
+			memset(sco_packet + 3, 0, sco_payload_length);
+			audio_input_paused = 1;
+		}
+		else
+		{
+			hfp_msbc_read_from_stream(sco_packet + 3, sco_payload_length);
+		}
+    }
+    else
+    {
+        memset(sco_packet + 3, 0, sco_payload_length);
+    }
+    little_endian_store_16(sco_packet, 0, sco_handle);
+    sco_packet[2] = sco_payload_length;
+    hci_send_sco_packet_buffer(sco_packet_length);
+    hci_request_sco_can_send_now_event();
+
+    count_sent++;
+    if ((count_sent % SCO_REPORT_PERIOD) == 0)
+        sco_report();
+}
+
+void processing_receive(uint8_t *packet, uint16_t size)
+{
+
+    dump_data = 1;
+
+    count_received++;
+    static uint32_t packets = 0;
+    static uint32_t crc_errors = 0;
+    static uint32_t data_received = 0;
+    static uint32_t byte_errors = 0;
+
+    data_received += size - 3;
+    packets++;
+    if (data_received > 100000)
+    {
+        printf("Summary: data %07u, packets %04u, packet with crc errors %0u, byte errors %04u\n", (unsigned int)data_received, (unsigned int)packets, (unsigned int)crc_errors, (unsigned int)byte_errors);
+        crc_errors = 0;
+        byte_errors = 0;
+        data_received = 0;
+        packets = 0;
+    }
+
+    switch (negotiated_codec)
+    {
+		case HFP_CODEC_MSBC:
+			processing_receive_mSBC(packet, size);
+			break;
+		default:
+			break;
+    }
+    dump_data = 0;
+}

--- a/main/processing_util.c
+++ b/main/processing_util.c
@@ -1,47 +1,89 @@
 #include "processing_util.h"
 
-static int		audio_input_paused = 0;
-static uint8_t	audio_input_ring_buffer_storage[2 * 8000];
-static btstack_ring_buffer_t audio_input_ring_buffer;
-
-static int		audio_output_paused = 0;
-static uint8_t	audio_output_ring_buffer_storage[2 * MSBC_PA_PREBUFFER_BYTES];
+static int audio_output_paused = 0;
+static uint8_t audio_output_ring_buffer_storage[2 * MSBC_PA_PREBUFFER_BYTES];
 static btstack_ring_buffer_t audio_output_ring_buffer;
 
-static int	dump_data = 1;
-static int	count_sent = 0;
-static int	count_received = 0;
-static int	negotiated_codec = -1;
+static int audio_input_paused = 0;
+static uint8_t audio_input_ring_buffer_storage[2 * 8000];
+static btstack_ring_buffer_t audio_input_ring_buffer;
 
+static int dump_data = 1;
+static int count_sent = 0;
+static int count_received = 0;
+static int negotiated_codec = -1;
+
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
 static btstack_sbc_decoder_state_t decoder_state;
+#endif
 
-int	num_audio_frames;
-int	num_samples_to_write;
+static btstack_cvsd_plc_state_t cvsd_plc_state;
+
+int num_samples_to_write;
+int num_audio_frames;
 unsigned int phase;
 
 static void playback_callback(int16_t *buffer, uint16_t num_samples)
 {
     uint32_t prebuffer_bytes;
-	prebuffer_bytes = MSBC_PA_PREBUFFER_BYTES;
+    switch (negotiated_codec)
+    {
+		case HFP_CODEC_MSBC:
+			prebuffer_bytes = MSBC_PA_PREBUFFER_BYTES;
+			break;
+		case HFP_CODEC_CVSD:
+		default:
+			prebuffer_bytes = CVSD_PA_PREBUFFER_BYTES;
+			break;
+    }
 
     if (audio_output_paused)
     {
         if (btstack_ring_buffer_bytes_available(&audio_output_ring_buffer) < prebuffer_bytes)
         {
+#ifdef ENABLE_SCO_STEREO_PLAYBACK
+            memset(buffer, 0, num_samples * BYTES_PER_FRAME * 2);
+#else
             memset(buffer, 0, num_samples * BYTES_PER_FRAME);
+#endif
             return;
         }
-        audio_output_paused = 0;
+        else
+        {
+            audio_output_paused = 0;
+        }
     }
 
     uint32_t bytes_read = 0;
+#ifdef ENABLE_SCO_STEREO_PLAYBACK
+    while (num_samples)
+    {
+        int16_t temp[16];
+        unsigned int bytes_to_read = btstack_min(num_samples * BYTES_PER_FRAME, sizeof(temp));
+        btstack_ring_buffer_read(&audio_output_ring_buffer, (uint8_t *)&temp[0], bytes_to_read, &bytes_read);
+        if (bytes_read == 0)
+            break;
+        unsigned int i;
+        for (i = 0; i < bytes_read / BYTES_PER_FRAME; i++)
+        {
+            *buffer++ = temp[i];
+            *buffer++ = temp[i];
+            num_samples--;
+        }
+    }
+#else
     btstack_ring_buffer_read(&audio_output_ring_buffer, (uint8_t *)buffer, num_samples * BYTES_PER_FRAME, &bytes_read);
     num_samples -= bytes_read / BYTES_PER_FRAME;
     buffer += bytes_read / BYTES_PER_FRAME;
+#endif
 
     if (num_samples)
     {
+#ifdef ENABLE_SCO_STEREO_PLAYBACK
+        memset(buffer, 0, num_samples * BYTES_PER_FRAME * 2);
+#else
         memset(buffer, 0, num_samples * BYTES_PER_FRAME);
+#endif
         audio_output_paused = 1;
     }
 }
@@ -59,7 +101,11 @@ static int audio_initialize(int sample_rate)
     const btstack_audio_sink_t *audio_sink = btstack_audio_sink_get_instance();
     if (audio_sink)
     {
+#ifdef ENABLE_SCO_STEREO_PLAYBACK
+        audio_sink->init(2, sample_rate, &playback_callback);
+#else
         audio_sink->init(1, sample_rate, &playback_callback);
+#endif
         audio_sink->start_stream();
         audio_output_paused = 1;
     }
@@ -92,6 +138,8 @@ static void audio_terminate(void)
     }
 }
 
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
+#include <stdio.h>
 static void handle_pcm_data(int16_t *data, int num_samples, int num_channels, int sample_rate, void *context)
 {
     UNUSED(context);
@@ -100,16 +148,20 @@ static void handle_pcm_data(int16_t *data, int num_samples, int num_channels, in
     UNUSED(num_samples);
     UNUSED(num_channels);
 
-    btstack_ring_buffer_write(&audio_output_ring_buffer, (uint8_t *)data, num_samples * num_channels * 2);
-}
+	log_pcm_data(data, num_samples);
 
+#if (SCO_DEMO_MODE == SCO_DEMO_MODE_MICROPHONE)
+    btstack_ring_buffer_write(&audio_output_ring_buffer, (uint8_t *)data, num_samples * num_channels * 2);
+#endif
+}
+#endif
+
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
 static void processing_init_mSBC(void)
 {
-    printf("Processing: Init mSBC\n");
-
+    printf("SCO Demo: Init mSBC\n");
     btstack_sbc_decoder_init(&decoder_state, SBC_MODE_mSBC, &handle_pcm_data, NULL);
     hfp_msbc_init();
-
     audio_initialize(MSBC_SAMPLE_RATE);
 }
 
@@ -117,13 +169,53 @@ static void processing_receive_mSBC(uint8_t *packet, uint16_t size)
 {
     btstack_sbc_decoder_process_data(&decoder_state, (packet[1] >> 4) & 3, packet + 3, size - 3);
 }
+#endif
+
+static void processing_init_CVSD(void)
+{
+    printf("SCO Demo: Init CVSD\n");
+    btstack_cvsd_plc_init(&cvsd_plc_state);
+    audio_initialize(CVSD_SAMPLE_RATE);
+}
+
+static void processing_receive_CVSD(uint8_t *packet, uint16_t size)
+{
+    int16_t audio_frame_out[128];
+    if (size > sizeof(audio_frame_out))
+    {
+        printf("processing_receive_CVSD: SCO packet larger than local output buffer - dropping data.\n");
+        return;
+    }
+
+    const int audio_bytes_read = size - 3;
+    const int num_samples = audio_bytes_read / BYTES_PER_FRAME;
+    int16_t audio_frame_in[128];
+    for (int i = 0; i < num_samples; i++)
+    {
+        audio_frame_in[i] = little_endian_read_16(packet, 3 + i * 2);
+    }
+
+    bool bad_frame = (packet[1] & 0x30) != 0;
+    btstack_cvsd_plc_process_data(&cvsd_plc_state, bad_frame, audio_frame_in, num_samples, audio_frame_out);
+    btstack_ring_buffer_write(&audio_output_ring_buffer, (uint8_t *)audio_frame_out, audio_bytes_read);
+}
 
 void processing_close(void)
 {
     printf("SCO demo close\n");
-
     printf("SCO demo statistics: ");
-    printf("Used mSBC with PLC, number of processed frames: \n - %d good frames, \n - %d zero frames, \n - %d bad frames.\n", decoder_state.good_frames_nr, decoder_state.zero_frames_nr, decoder_state.bad_frames_nr);
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
+    if (negotiated_codec == HFP_CODEC_MSBC)
+    {
+        printf("Used mSBC with PLC, number of processed frames: \n - %d good frames, \n - %d zero frames, \n - %d bad frames.\n", decoder_state.good_frames_nr, decoder_state.zero_frames_nr, decoder_state.bad_frames_nr);
+    }
+    else
+#endif
+    {
+        printf("Used CVSD with PLC, number of proccesed frames: \n - %d good frames, \n - %d bad frames.\n", cvsd_plc_state.good_frames_nr, cvsd_plc_state.bad_frames_nr);
+    }
+
+    negotiated_codec = -1;
     audio_terminate();
 }
 
@@ -131,14 +223,29 @@ void processing_set_codec(uint8_t codec)
 {
     if (negotiated_codec == codec)
         return;
+
     negotiated_codec = codec;
-    processing_init_mSBC();
+    if (negotiated_codec == HFP_CODEC_MSBC)
+    {
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
+        processing_init_mSBC();
+#endif
+    }
+    else
+    {
+        processing_init_CVSD();
+    }
 }
 
 void processing_init(void)
 {
-    printf("Processing: Sending and receiving audio via btstack_audio.\n");
-    hci_set_sco_voice_setting(0x60);
+#ifdef ENABLE_CLASSIC_LEGACY_CONNECTIONS_FOR_SCO_DEMOS
+    printf("Disable BR/EDR Secure Connctions due to incompatibilities with SCO connections\n");
+    gap_secure_connections_enable(false);
+#endif
+
+    printf("SCO Demo: Sending and receiving audio via btstack_audio.\n");
+    hci_set_sco_voice_setting(0x60); // linear, unsigned, 16-bit, CVSD
 }
 
 void sco_report(void)
@@ -153,48 +260,89 @@ void processing_send(hci_con_handle_t sco_handle)
 
     int sco_packet_length = hci_get_sco_packet_length();
     int sco_payload_length = sco_packet_length - 3;
-
     hci_reserve_packet_buffer();
-    uint8_t *sco_packet = hci_get_outgoing_packet_buffer();
 
+    uint8_t *sco_packet = hci_get_outgoing_packet_buffer();
     if (btstack_audio_source_get_instance())
     {
-		if (audio_input_paused)
-		{
-			if (btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= MSBC_PA_PREBUFFER_BYTES)
-			{
-				audio_input_paused = 0;
-			}
-		}
+        if (negotiated_codec == HFP_CODEC_MSBC)
+        {
+            if (audio_input_paused)
+            {
+                if (btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= MSBC_PA_PREBUFFER_BYTES)
+                {
+                    audio_input_paused = 0;
+                }
+            }
 
-		if (!audio_input_paused)
-		{
-			int num_samples = hfp_msbc_num_audio_samples_per_frame();
-			if (num_samples > MAX_NUM_MSBC_SAMPLES)
-				return;
-			if (hfp_msbc_can_encode_audio_frame_now() && btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= (unsigned int)(num_samples * BYTES_PER_FRAME))
-			{
-				int16_t sample_buffer[MAX_NUM_MSBC_SAMPLES];
-				uint32_t bytes_read;
-				btstack_ring_buffer_read(&audio_input_ring_buffer, (uint8_t *)sample_buffer, num_samples * BYTES_PER_FRAME, &bytes_read);
-				hfp_msbc_encode_audio_frame(sample_buffer);
-				num_audio_frames++;
-			}
-			if (hfp_msbc_num_bytes_in_stream() < sco_payload_length)
-			{
-				log_error("mSBC stream should not be empty.");
-			}
-		}
+            if (!audio_input_paused)
+            {
+                int num_samples = hfp_msbc_num_audio_samples_per_frame();
+                if (num_samples > MAX_NUM_MSBC_SAMPLES)
+                    return;
+                if (hfp_msbc_can_encode_audio_frame_now() && btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= (unsigned int)(num_samples * BYTES_PER_FRAME))
+                {
+                    int16_t sample_buffer[MAX_NUM_MSBC_SAMPLES];
+                    uint32_t bytes_read;
+                    btstack_ring_buffer_read(&audio_input_ring_buffer, (uint8_t *)sample_buffer, num_samples * BYTES_PER_FRAME, &bytes_read);
+                    hfp_msbc_encode_audio_frame(sample_buffer);
+                    num_audio_frames++;
+                }
+                if (hfp_msbc_num_bytes_in_stream() < sco_payload_length)
+                {
+                    log_error("mSBC stream should not be empty.");
+                }
+            }
 
-		if (audio_input_paused || hfp_msbc_num_bytes_in_stream() < sco_payload_length)
-		{
-			memset(sco_packet + 3, 0, sco_payload_length);
-			audio_input_paused = 1;
-		}
-		else
-		{
-			hfp_msbc_read_from_stream(sco_packet + 3, sco_payload_length);
-		}
+            if (audio_input_paused || hfp_msbc_num_bytes_in_stream() < sco_payload_length)
+            {
+                memset(sco_packet + 3, 0, sco_payload_length);
+                audio_input_paused = 1;
+            }
+            else
+            {
+                hfp_msbc_read_from_stream(sco_packet + 3, sco_payload_length);
+            }
+        }
+        else
+        {
+            log_debug("send: bytes avail %u, free %u", btstack_ring_buffer_bytes_available(&audio_input_ring_buffer), btstack_ring_buffer_bytes_free(&audio_input_ring_buffer));
+
+            int bytes_to_copy = sco_payload_length;
+            if (audio_input_paused)
+            {
+                if (btstack_ring_buffer_bytes_available(&audio_input_ring_buffer) >= CVSD_PA_PREBUFFER_BYTES)
+                {
+                    audio_input_paused = 0;
+                }
+            }
+
+            uint16_t pos = 0;
+            uint8_t *sample_data = &sco_packet[3];
+            if (!audio_input_paused)
+            {
+                uint32_t bytes_read = 0;
+                btstack_ring_buffer_read(&audio_input_ring_buffer, sample_data, bytes_to_copy, &bytes_read);
+                if (btstack_is_big_endian())
+                {
+                    unsigned int i;
+                    for (i = 0; i < bytes_read; i += 2)
+                    {
+                        uint8_t tmp = sample_data[i * 2];
+                        sample_data[i * 2] = sample_data[i * 2 + 1];
+                        sample_data[i * 2 + 1] = tmp;
+                    }
+                }
+                bytes_to_copy -= bytes_read;
+                pos += bytes_read;
+            }
+
+            if (bytes_to_copy)
+            {
+                memset(sample_data + pos, 0, bytes_to_copy);
+                audio_input_paused = 1;
+            }
+        }
     }
     else
     {
@@ -204,18 +352,17 @@ void processing_send(hci_con_handle_t sco_handle)
     sco_packet[2] = sco_payload_length;
     hci_send_sco_packet_buffer(sco_packet_length);
     hci_request_sco_can_send_now_event();
-
     count_sent++;
+
     if ((count_sent % SCO_REPORT_PERIOD) == 0)
         sco_report();
 }
 
 void processing_receive(uint8_t *packet, uint16_t size)
 {
-
     dump_data = 1;
-
     count_received++;
+
     static uint32_t packets = 0;
     static uint32_t crc_errors = 0;
     static uint32_t data_received = 0;
@@ -234,8 +381,13 @@ void processing_receive(uint8_t *packet, uint16_t size)
 
     switch (negotiated_codec)
     {
+#ifdef ENABLE_HFP_WIDE_BAND_SPEECH
 		case HFP_CODEC_MSBC:
 			processing_receive_mSBC(packet, size);
+			break;
+#endif
+		case HFP_CODEC_CVSD:
+			processing_receive_CVSD(packet, size);
 			break;
 		default:
 			break;

--- a/main/processing_util.c
+++ b/main/processing_util.c
@@ -139,7 +139,6 @@ static void audio_terminate(void)
 }
 
 #ifdef ENABLE_HFP_WIDE_BAND_SPEECH
-#include <stdio.h>
 static void handle_pcm_data(int16_t *data, int num_samples, int num_channels, int sample_rate, void *context)
 {
     UNUSED(context);
@@ -148,7 +147,7 @@ static void handle_pcm_data(int16_t *data, int num_samples, int num_channels, in
     UNUSED(num_samples);
     UNUSED(num_channels);
 
-	log_pcm_data(data, num_samples);
+	send_pcm_data(data, num_samples);
 
 #if (SCO_DEMO_MODE == SCO_DEMO_MODE_MICROPHONE)
     btstack_ring_buffer_write(&audio_output_ring_buffer, (uint8_t *)data, num_samples * num_channels * 2);

--- a/main/processing_util.h
+++ b/main/processing_util.h
@@ -1,13 +1,16 @@
 #ifndef PROCESSING_UTIL_H
 # define PROCESSING_UTIL_H
 
+# define SCO_CVSD_PA_PREBUFFER_MS 50
 # define SCO_MSBC_PA_PREBUFFER_MS 50
 # define SCO_REPORT_PERIOD 100
 
 # define NUM_CHANNELS 1
+# define CVSD_SAMPLE_RATE 8000
 # define MSBC_SAMPLE_RATE 16000
 # define BYTES_PER_FRAME 2
 
+# define CVSD_PA_PREBUFFER_BYTES (SCO_CVSD_PA_PREBUFFER_MS * CVSD_SAMPLE_RATE / 1000 * BYTES_PER_FRAME)
 # define MSBC_PA_PREBUFFER_BYTES (SCO_MSBC_PA_PREBUFFER_MS * MSBC_SAMPLE_RATE / 1000 * BYTES_PER_FRAME)
 
 # define MAX_NUM_MSBC_SAMPLES (16 * 8)
@@ -16,10 +19,13 @@
 # include "btstack_audio.h"
 # include "btstack_debug.h"
 # include "btstack_ring_buffer.h"
+# include "classic/btstack_cvsd_plc.h"
 # include "classic/btstack_sbc.h"
 # include "classic/hfp.h"
 # include "classic/hfp_msbc.h"
 # include "hci.h"
+
+# include "pcm_util.h"
 
 void	processing_close(void);
 void	processing_init(void);

--- a/main/processing_util.h
+++ b/main/processing_util.h
@@ -1,0 +1,30 @@
+#ifndef PROCESSING_UTIL_H
+# define PROCESSING_UTIL_H
+
+# define SCO_MSBC_PA_PREBUFFER_MS 50
+# define SCO_REPORT_PERIOD 100
+
+# define NUM_CHANNELS 1
+# define MSBC_SAMPLE_RATE 16000
+# define BYTES_PER_FRAME 2
+
+# define MSBC_PA_PREBUFFER_BYTES (SCO_MSBC_PA_PREBUFFER_MS * MSBC_SAMPLE_RATE / 1000 * BYTES_PER_FRAME)
+
+# define MAX_NUM_MSBC_SAMPLES (16 * 8)
+
+# include <stdio.h>
+# include "btstack_audio.h"
+# include "btstack_debug.h"
+# include "btstack_ring_buffer.h"
+# include "classic/btstack_sbc.h"
+# include "classic/hfp.h"
+# include "classic/hfp_msbc.h"
+# include "hci.h"
+
+void	processing_close(void);
+void	processing_init(void);
+void	processing_receive(uint8_t *packet, uint16_t size);
+void	processing_send(hci_con_handle_t con_handle);
+void	processing_set_codec(uint8_t codec);
+
+#endif


### PR DESCRIPTION
## Summary
PCM 데이터 처리에 대한 Util을 구성하였습니다.

## Description
- `main.c`에서 BLE 및 HFP 프로토콜 각각을 초기화하고 구성합니다. 이는 각각 `ble_util.c`와 `hfp_util.c`에 구현되어 있습니다.
- HFP를 통해서 mSBC 코덱으로 인식된 음성 데이터는 BTStack 내 자체 디코딩 과정을 통해 PCM Binary 데이터로 변환됩니다. 이는 `processing_util.c`에 구현되어 있으며, [예제](https://github.com/atomic14/esp32-hsp-hf)를 참고하여 구현하였습니다.
- PCM Binary 데이터로 변환된 음성 데이터는 `pcm_util.c` 내부에 구현된 `send_pcm_data` 함수를 통해 BLE 버퍼 데이터로 변환되어 BLE 프로토콜로 Notify 됩니다. 현재 구현 상, 무작정 BLE로 전송하도록 되어있는데, 이를 버퍼로 재구성하여 BLE 지연을 최소화할 예정입니다.